### PR TITLE
First full version of HDF5Serializable

### DIFF
--- a/src/HDFJavaUtils/DatasetUtils.java
+++ b/src/HDFJavaUtils/DatasetUtils.java
@@ -146,11 +146,59 @@ public class DatasetUtils {
 			typeID = HDF5Constants.H5T_NATIVE_INT;
 		}
 		final H5Datatype type = new H5Datatype(typeID);
+		long[] actualDims = intToLongArr(getDimensions(data));
+		Object[] fillObj = {fill};
 		try {
-			file.createScalarDS("/" + name, null, type, dims, maxDims, chunkDims, gzip, fill, data);
+			H5ScalarDS dset = (H5ScalarDS)file.createScalarDS("/" + name, null,
+					type, actualDims, maxDims, chunkDims, gzip, fillObj, data);
+			dset.extend(dims);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+	
+	public void writeFixedDS(String fileName, String name, long[] dims, Object data, long[] chunkDims,
+			int gzip, Object fill) {
+		H5File file = new H5File(fileName, H5File.WRITE);
+		int typeID = DataTypeUtils.getDataType(data);
+		if (typeID == HDF5Constants.H5T_NATIVE_CHAR) {
+			data = copyArrayCharToInt(data);
+			typeID = HDF5Constants.H5T_NATIVE_INT;
+		} else if (typeID == HDF5Constants.H5T_NATIVE_HBOOL) {
+			data = copyArrayBoolToInt(data);
+			typeID = HDF5Constants.H5T_NATIVE_INT;
+		}
+		final H5Datatype type = new H5Datatype(typeID);
+		long[] actualDims = intToLongArr(getDimensions(data));
+		Object[] fillObj = {fill};
+		try {
+			H5ScalarDS dset = (H5ScalarDS)file.createScalarDS("/" + name, null,
+					type, actualDims, dims, chunkDims, gzip, fillObj, data);
+			dset.extend(dims);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	public void writeFixedDS(String fileName, String name, long[] dims, Object data, long[] chunkDims, Object fill) {
+		writeFixedDS(fileName, name, dims, data, chunkDims, 0, fill);
+	}
+	
+	public void writeFixedDS(String fileName, String name, long[] dims, Object data, Object fill) {
+		long[] chunkDims = null;
+		writeFixedDS(fileName, name, dims, data, chunkDims, fill);
+	}
+	
+	public void writeFixedDS(String fileName, String name, long[] dims, Object data) {
+		writeFixedDS(fileName, name, dims, data, null);
+	}
+	
+	public void writeFixedDS(String fileName, String name, long[] dims, Object data, long[] chunkDims, int gzip) {
+		writeFixedDS(fileName, name ,dims, data, chunkDims, gzip, null);
+	}
+	
+	public void writeFixedDS(String fileName, String name, long[] dims, Object data, long[] chunkDims) {
+		writeFixedDS(fileName, name ,dims, data, chunkDims, 0);
 	}
 	
 	

--- a/src/HDFJavaUtils/ObjectInputStream.java
+++ b/src/HDFJavaUtils/ObjectInputStream.java
@@ -884,45 +884,63 @@ public class ObjectInputStream {
 						name = defaultPath + "/" + path + "/" + localGroup + "/" + name;
 						
 						Class<?> type = field.getType();
-						
-						if (PRIMITIVE_TYPE.contains(type)) {
-							if (type.equals(int.class)) {
-								field.set(obj, readInt(name));
-							} else if (type.equals(long.class)) {
-								field.set(obj, readLong(name));
-							} else if (type.equals(double.class)) {
-								field.set(obj, readDouble(name));
-							} else if (type.equals(float.class)) {
-								field.set(obj, readFloat(name));
-							} else if (type.equals(short.class)) {
-								field.set(obj, readShort(name));
-							} else if (type.equals(char.class)) {
-								field.set(obj, readChar(name));
-							} else if (type.equals(boolean.class)) {
-								field.set(obj, readBoolean(name));
-							} else if (type.equals(byte.class)) {
-								field.set(obj, readByte(name));
-							}
-						} else if(WRAPPER_TYPE.contains(type)) {
-							if (type.equals(Integer.class)) {
-								field.set(obj, readInt(name));
-							} else if (type.equals(Long.class)) {
-								field.set(obj, readLong(name));
-							} else if (type.equals(Double.class)) {
-								field.set(obj, readDouble(name));
-							} else if (type.equals(Float.class)) {
-								field.set(obj, readFloat(name));
-							} else if (type.equals(Short.class)) {
-								field.set(obj, readShort(name));
-							} else if (type.equals(Character.class)) {
-								field.set(obj, readChar(name));
-							} else if (type.equals(String.class)) {
-								field.set(obj, readString(name));
-							} else if (type.equals(Boolean.class)) {
-								field.set(obj, readBoolean(name));
-							} else if (type.equals(Byte.class)) {
-								field.set(obj, readByte(name));
-							}
+						if (type.equals(int.class) || type.equals(Integer.class)) {
+							field.set(obj, readInt(name));
+						} else if (type.equals(long.class) || type.equals(Long.class)) {
+							field.set(obj, readLong(name));
+						} else if (type.equals(double.class) || type.equals(Double.class)) {
+							field.set(obj, readDouble(name));
+						} else if (type.equals(short.class) || type.equals(Short.class)) {
+							field.set(obj, readShort(name));
+						} else if (type.equals(float.class) || type.equals(Float.class)) {
+							field.set(obj, readFloat(name));
+						} else if (type.equals(byte.class) || type.equals(Byte.class)) {
+							field.set(obj, readByte(name));
+						} else if (type.equals(boolean.class) || type.equals(Boolean.class)) {
+							field.set(obj, readBoolean(name));
+						} else if (type.equals(char.class) || type.equals(Character.class)) {
+							field.set(obj, readChar(name));
+						} else if (type.equals(String.class)) {
+							field.set(obj, readString(name));
+//						}
+//						if (PRIMITIVE_TYPE.contains(type)) {
+//							if (type.equals(int.class)) {
+//								field.set(obj, readInt(name));
+//							} else if (type.equals(long.class)) {
+//								field.set(obj, readLong(name));
+//							} else if (type.equals(double.class)) {
+//								field.set(obj, readDouble(name));
+//							} else if (type.equals(float.class)) {
+//								field.set(obj, readFloat(name));
+//							} else if (type.equals(short.class)) {
+//								field.set(obj, readShort(name));
+//							} else if (type.equals(char.class)) {
+//								field.set(obj, readChar(name));
+//							} else if (type.equals(boolean.class)) {
+//								field.set(obj, readBoolean(name));
+//							} else if (type.equals(byte.class)) {
+//								field.set(obj, readByte(name));
+//							}
+//						} else if(WRAPPER_TYPE.contains(type)) {
+//							if (type.equals(Integer.class)) {
+//								field.set(obj, readInt(name));
+//							} else if (type.equals(Long.class)) {
+//								field.set(obj, readLong(name));
+//							} else if (type.equals(Double.class)) {
+//								field.set(obj, readDouble(name));
+//							} else if (type.equals(Float.class)) {
+//								field.set(obj, readFloat(name));
+//							} else if (type.equals(Short.class)) {
+//								field.set(obj, readShort(name));
+//							} else if (type.equals(Character.class)) {
+//								field.set(obj, readChar(name));
+//							} else if (type.equals(String.class)) {
+//								field.set(obj, readString(name));
+//							} else if (type.equals(Boolean.class)) {
+//								field.set(obj, readBoolean(name));
+//							} else if (type.equals(Byte.class)) {
+//								field.set(obj, readByte(name));
+//							}
 						} else if (type.isArray()) {
 							field.set(obj, readArray(name, DataTypeUtils.getDataType(field), field.get(obj)));
 						} else if (List.class.isAssignableFrom(type)) {

--- a/src/HDFJavaUtils/ObjectOutputStream.java
+++ b/src/HDFJavaUtils/ObjectOutputStream.java
@@ -87,9 +87,9 @@ public class ObjectOutputStream {
 	 * @param name
 	 *            The name of the dataset
 	 */
-	public void writeDouble(double val, String name) {
+	public void writeDouble(Object val, String name) {
 		final H5Datatype type = new H5Datatype(HDF5Constants.H5T_NATIVE_DOUBLE);
-		double[] data = { val };
+		double[] data = { (double)val };
 		long[] dims = { 1 };
 		writeData(type, data, dims, name);
 	}
@@ -132,9 +132,9 @@ public class ObjectOutputStream {
 	 * @param name
 	 *            The name of the dataset
 	 */
-	public void writeFloat(float val, String name) {
+	public void writeFloat(Object val, String name) {
 		final H5Datatype type = new H5Datatype(HDF5Constants.H5T_NATIVE_FLOAT);
-		float[] data = { val };
+		float[] data = { (float)val };
 		long[] dims = { 1 };
 		writeData(type, data, dims, name);
 	}
@@ -147,9 +147,9 @@ public class ObjectOutputStream {
 	 * @param name
 	 *            The name of the dataset
 	 */
-	public void writeBoolean(boolean val, String name) {
+	public void writeBoolean(Object val, String name) {
 		final H5Datatype type = new H5Datatype(HDF5Constants.H5T_NATIVE_HBOOL);
-		int[] data = { val ? 1 : 0 };
+		int[] data = { (boolean)val ? 1 : 0 };
 		long[] dims = { 1 };
 		writeData(type, data, dims, name);
 	}
@@ -162,9 +162,9 @@ public class ObjectOutputStream {
 	 * @param name
 	 *            The name of the dataset
 	 */
-	public void writeLong(long val, String name) {
+	public void writeLong(Object val, String name) {
 		final H5Datatype type = new H5Datatype(HDF5Constants.H5T_NATIVE_LONG);
-		long[] data = { val };
+		long[] data = { (long)val };
 		long[] dims = { 1 };
 		writeData(type, data, dims, name);
 	}
@@ -177,9 +177,9 @@ public class ObjectOutputStream {
 	 * @param name
 	 *            The name of the dataset
 	 */
-	public void writeShort(short val, String name) {
+	public void writeShort(Object val, String name) {
 		final H5Datatype type = new H5Datatype(HDF5Constants.H5T_NATIVE_SHORT);
-		short[] data = { val };
+		short[] data = { (short)val };
 		long[] dims = { 1 };
 		writeData(type, data, dims, name);
 	}
@@ -192,9 +192,9 @@ public class ObjectOutputStream {
 	 * @param name
 	 *            The name of the dataset
 	 */
-	public void writeByte(byte val, String name) {
+	public void writeByte(Object val, String name) {
 		final H5Datatype type = new H5Datatype(HDF5Constants.H5T_NATIVE_INT8);
-		byte[] data = { val };
+		byte[] data = { (byte)val };
 		long[] dims = { 1 };
 		writeData(type, data, dims, name);
 	}
@@ -207,9 +207,9 @@ public class ObjectOutputStream {
 	 * @param name
 	 *            The name of the dataset
 	 */
-	public void writeChar(char val, String name) {
+	public void writeChar(Object val, String name) {
 		final H5Datatype type = new H5Datatype(HDF5Constants.H5T_NATIVE_CHAR);
-		int[] data = { val };
+		int[] data = { (int) ((char)val) };
 		long[] dims = { 1 };
 		writeData(type, data, dims, name);
 	}
@@ -714,44 +714,64 @@ public class ObjectOutputStream {
 						name = defaultPath + "/" + path + "/" + localGroup + "/" + name;
 
 						Class<?> type = field.getType();
-						 if(PRIMITIVE_TYPE.contains(type)) {
-							if (type.equals(int.class)) {
-								writeInt(field.get(obj), name);
-							} else if (type.equals(long.class)) {
-								writeLong(field.getLong(obj), name);
-							} else if (type.equals(double.class)) {
-								writeDouble(field.getDouble(obj), name);
-							} else if (type.equals(float.class)) {
-								writeFloat(field.getFloat(obj), name);
-							} else if (type.equals(short.class)) {
-								writeShort(field.getShort(obj), name);
-							} else if (type.equals(char.class)) {
-								writeChar(field.getChar(obj), name);
-							} else if (type.equals(boolean.class)) {
-								writeBoolean(field.getBoolean(obj), name);
-							} else if (type.equals(byte.class)) {
-								writeByte(field.getByte(obj), name);
-							}
-						} else if (WRAPPER_TYPE.contains(type)) {
-							if (type.equals(Integer.class)) {
-								writeInt(field.get(obj), name);
-							} else if (type.equals(Long.class)) {
-								writeLong(field.getLong(obj), name);
-							} else if (type.equals(Double.class)) {
-								writeDouble(field.getDouble(obj), name);
-							} else if (type.equals(Float.class)) {
-								writeFloat(field.getFloat(obj), name);
-							} else if (type.equals(Short.class)) {
-								writeShort(field.getShort(obj), name);
-							} else if (type.equals(Character.class)) {
-								writeChar(field.getChar(obj), name);
-							} else if (type.equals(String.class)) {
-								writeString((String) field.get(obj), name);
-							} else if (type.equals(Boolean.class)) {
-								writeBoolean(field.getBoolean(obj), name);
-							} else if (type.equals(Byte.class)) {
-								writeByte(field.getByte(obj), name);
-							}
+						if (type.equals(int.class) || type.equals(Integer.class)) {
+							writeInt(field.get(obj), name);
+						} else if (type.equals(long.class) || type.equals(Long.class)) {
+							writeLong(field.get(obj), name);
+						} else if (type.equals(double.class) || type.equals(Double.class)) {
+							writeDouble(field.get(obj), name);
+						} else if (type.equals(short.class) || type.equals(Short.class)) {
+							writeShort(field.get(obj), name);
+						} else if (type.equals(float.class) || type.equals(Float.class)) {
+							writeFloat(field.get(obj), name);
+						} else if (type.equals(byte.class) || type.equals(Byte.class)) {
+							writeByte(field.get(obj), name);
+						} else if (type.equals(boolean.class) || type.equals(Boolean.class)) {
+							writeBoolean(field.get(obj), name);
+						} else if (type.equals(char.class) || type.equals(Character.class)) {
+							writeChar(field.get(obj), name);
+						} else if (type.equals(String.class)) {
+							writeString((String) field.get(obj), name);
+//						}
+//						
+//						 if(PRIMITIVE_TYPE.contains(type)) {
+//							if (type.equals(int.class)) {
+//								writeInt(field.get(obj), name);
+//							} else if (type.equals(long.class)) {
+//								writeLong(field.get(obj), name);
+//							} else if (type.equals(double.class)) {
+//								writeDouble(field.get(obj), name);
+//							} else if (type.equals(float.class)) {
+//								writeFloat(field.get(obj), name);
+//							} else if (type.equals(short.class)) {
+//								writeShort(field.get(obj), name);
+//							} else if (type.equals(char.class)) {
+//								writeChar(field.get(obj), name);
+//							} else if (type.equals(boolean.class)) {
+//								writeBoolean(field.get(obj), name);
+//							} else if (type.equals(byte.class)) {
+//								writeByte(field.get(obj), name);
+//							}
+//						} else if (WRAPPER_TYPE.contains(type)) {
+//							if (type.equals(Integer.class)) {
+//								writeInt(field.get(obj), name);
+//							} else if (type.equals(Long.class)) {
+//								writeLong(field.get(obj), name);
+//							} else if (type.equals(Double.class)) {
+//								writeDouble(field.get(obj), name);
+//							} else if (type.equals(Float.class)) {
+//								writeFloat(field.get(obj), name);
+//							} else if (type.equals(Short.class)) {
+//								writeShort(field.get(obj), name);
+//							} else if (type.equals(Character.class)) {
+//								writeChar(field.get(obj), name);
+//							} else if (type.equals(String.class)) {
+//								writeString((String) field.get(obj), name);
+//							} else if (type.equals(Boolean.class)) {
+//								writeBoolean(field.get(obj), name);
+//							} else if (type.equals(Byte.class)) {
+//								writeByte(field.get(obj), name);
+//							}
 						}  else if (type.isArray()) {
 							if (dims[0] == -1) {
 								int[] temp = getDimensions(field.get(obj));


### PR DESCRIPTION
ObjectOutputStream and ObjectInputStream finished
can serialize any primitive/primitive wrapper object, arrays, and collections.
Full Object recursive support for all previously mentioned data structures. 
Implementation of writeObject and readObject Override method to provide custom serialization.
This is not true serialization where it transfers the file into bits but serialization that makes the file easily readable to a user.
The interfaces provide tests and some basic options, more user options in the future.
DataTypeUtils, SubsetSelect, and DatasetUtils still in progress.

Testspace is just automatic testing.